### PR TITLE
Adding modification to GEM data format according to V1

### DIFF
--- a/dqm-root/Makefile
+++ b/dqm-root/Makefile
@@ -3,7 +3,7 @@
 #
 BUILD_HOME:=$(shell pwd)/../..
 
-CC=g++-4.9.3
+CC=g++
 CCFLAGS=-O0 -g3 -fno-inline -Wall -fPIC -pthread -m64
 ADDFLAGS=-std=c++11
 RC=rootcint

--- a/gemtreewriter/Makefile
+++ b/gemtreewriter/Makefile
@@ -9,7 +9,7 @@ ROOTLIBS  =$(shell root-config --libs)
 ROOTGLIBS =$(shell root-config --glibs) 
 ROOTINC   =$(shell root-config --incdir)
 
-CC=g++-4.9.3
+CC=g++
 CCFLAGS=-O0 -g3 -fno-inline -Wall -fPIC ${ROOTCFLAGS}
 ADDFLAGS=-std=c++0x
 RC=rootcint

--- a/gemtreewriter/include/GEMAMC13EventFormat.h
+++ b/gemtreewriter/include/GEMAMC13EventFormat.h
@@ -105,9 +105,15 @@ class GEBdata
 
     //GEM chamber header
 
+      //////////////////////////////////////////
+      // Currently the code below is substituted with zero suppressed words counter
       //!Zero Suppression Flags:24  (8 zeroes):8
       /*!Bitmask indicating if certain VFAT blocks have been zero suppressed*/
-      uint32_t m_ZeroSup;
+      //uint32_t m_ZeroSup;
+      ///////////////////////////////////////////
+
+      //!Zero suppressed words counter
+      uint16_t m_ZeroSupWordsCnt;
       //!Input ID:5    000:3
       /*!GLIB input ID (starting at 0)*/
       uint8_t m_InputID;   
@@ -135,28 +141,38 @@ class GEBdata
       uint8_t m_InFu;    
       //!(7 0's):7    Stuck data:1    
       /*!Input status (warning): Data in InFIFO or EvtFIFO when L1A FIFO was empty. Only resets with resync or reset*/
-		  uint8_t m_Stuckd; 
+      uint8_t m_Stuckd; 
+      //!OH BC, bits [31:20]
+      uint16_t m_OHBC;
+      //!OH EC, bits [19:0]
+      uint32_t m_OHEC;
 
   public:
     //!Empty constructor. Functions used to assign data members.
     GEBdata(){};
     //!Constrcutor requirng arguments.
-    GEBdata(const uint32_t &ZeroSup_, 
+    //GEBdata(const uint32_t &ZeroSup_, --> see comment at l109 of this file
+    GEBdata(const uint16_t &ZeroSupWordsCnt_, 
               const uint8_t &InputID_, 
               const uint16_t &Vwh_, 
               const uint16_t &ErrorC_, 
               const uint16_t &OHCRC_, 
               const uint16_t &Vwt_,
               const uint8_t &InFu_,
-              const uint8_t &Stuckd_) : 
-          m_ZeroSup(ZeroSup_),                                
+              const uint8_t &Stuckd_,
+              const uint16_t &OHBC_,
+              const uint32_t &OHEC_) : 
+          //m_ZeroSup(ZeroSup_), --> see comment at l109 of this file
+          m_ZeroSupWordsCnt(ZeroSupWordsCnt_),                                
           m_InputID(InputID_),
           m_Vwh(Vwh_),                                  
           m_ErrorC(ErrorC_),
           m_OHCRC(OHCRC_),                                    
           m_Vwt(Vwt_),                             
           m_InFu(InFu_),                                   
-          m_Stuckd(Stuckd_){}  
+          m_Stuckd(Stuckd_),
+          m_OHBC(OHBC_),
+          m_OHEC(OHEC_){}  
     //!Destructor for the class.
     ~GEBdata(){vfatd.clear();}
 
@@ -167,7 +183,8 @@ class GEBdata
      */
     void setChamberHeader(uint64_t word)
     {
-      m_ZeroSup = 0x00ffffff & (word >> 40);        /*!Zero Suppression*/
+      //m_ZeroSup = 0x00ffffff & (word >> 40);        /*!Zero Suppression --> see comment at l109 of this file*/
+      m_ZeroSupWordsCnt = 0x0fff & (word >> 40);        /*!Zero suppressed words counter*/
       m_InputID = 0b00011111 & (word >> 35);        /*!GLIB Input ID*/
       m_Vwh = 0x0fff & (word >> 23);                /*!VFAT word count*/
       m_ErrorC = 0b0001111111111111 & (word);    /*!Thirteen Flags*/
@@ -201,9 +218,12 @@ class GEBdata
       m_Vwt = 0x0fff & (word >> 36);  /*!VFAT word count*/
       m_InFu = 0x0f & (word >> 35);   /*!InFIFO underflow*/
       m_Stuckd = 0x01 & (word >> 34); /*!Stuck data*/
+      m_OHBC = 0x0fff & (word >> 20); /*!OH BC*/
+      m_OHEC = 0x000fffff & (word);   /*!OH EC*/
     }
 
-    uint32_t ZeroSup()  {return m_ZeroSup;}   ///<Returns Zero Suppression flags
+    //uint32_t ZeroSup()  {return m_ZeroSup;}   ///<Returns Zero Suppression flags --> see comment at l109 of this file
+    uint16_t ZeroSupWordsCnt()  {return m_ZeroSupWordsCnt;}   ///<Returns Zero suppression words counter
     uint8_t  InputID()  {return m_InputID;}   ///<Returns GLIB input ID
     uint16_t Vwh()      {return m_Vwh;}       ///<Returns VFAT word count (size of VFAT payload)
     uint16_t ErrorC()   {return m_ErrorC;}    ///<Returns thirteen flags in GEM Chamber Header
@@ -212,6 +232,8 @@ class GEBdata
     uint16_t Vwt()      {return m_Vwt;}       ///<Returns VFAT word count
     uint8_t  InFu()     {return m_InFu;}      ///<Returns InFIFO underflow flag
     uint8_t  Stuckd()   {return m_Stuckd;}    ///<Returns Stuck data flag
+    uint16_t  OHBC()    {return m_OHBC;}      ///<Returns Optohybrid BC
+    uint32_t  OHEC()    {return m_OHEC;}      ///<Returns Optohybrid EC
 
     //!Adds VFAT data to the vector
     void v_add(VFATdata v){vfatd.push_back(v);}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
GEM chamber trailer bits [31:0] were previously unused, but now they include OH EC and BC. As far as I know the bits [19:0] of those 32 bits is OH EC, and bits [31:20] is the OH BC (this depends on the OH firmware, so I'm not 100% sure, but I think it's like that as far as I can see from OH firmware code).
GEM chamber header contained 24 bits for zero suppression flags (those are bits [63:40] of the chamber header), but these were never implemented in the firmware due to difficulty figuring out which exact VFAT was actually zero suppressed. What I did in version 1 format is that I added a counter of zero suppressed 64bit words (1 VFAT packet consists of 3 such words). This counter is 12 bits wide and is now sitting in chamber header bits [51:40]. The chamber header bits [63:52] are still unused and are always 0.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Making data format even with FW implementation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
not yet tested, need some data
### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->