### PR TITLE
Stripping the histograms to reduce memory consumption

### DIFF
--- a/dqm-root/src/common/AMC13_histogram.cxx
+++ b/dqm-root/src/common/AMC13_histogram.cxx
@@ -24,23 +24,17 @@ class AMC13_histogram: public Hardware_histogram
       }
       m_dir->cd();
       Control_bit5 = new TH1F("Control_Bit5", "Control Bit 5", 15,  0x0 , 0xf);
-      Control_bitA = new TH1F("Control_BitA", "Control Bit A", 15,  0x0 , 0xf); 
+      Control_bitA = new TH1F("Control_BitA", "Control Bit A", 15,  0x0 , 0xf);
       Evt_ty       = new TH1F("Evt_ty", "Evt_ty", 15, 0x0, 0xf);
-      //LV1_id       = new TH1F("LV1_id", "LV1_id", 0xffffff, 0x0, 0xffffff);
-      BX_id        = new TH1F("Bx_id", "Bx_id", 4095, 0x0, 0xfff);
       Source_id    = new TH1F("Source_id", "Source_id", 4095, 0x0, 0xfff);
       CalTyp       = new TH1F("CalTyp", "CalTyp", 15, 0x0, 0xf);
       nAMC         = new TH1F("nAMC", "nAMC", 12, 0, 12);
       OrN          = new TH1D("OrN", "OrN", 0xffffffff, 0x0, 0xffffffff);// N bins overflow!!
-      //CRC_amc13    = new TH1F("CRC_amc13", "CRC_amc13", 0xffffffff, 0x0, 0xffffffff);// N bins overflow!!
       Blk_NoT      = new TH1F("Blk_NoT", "Blk_NoT", 255, 0x0, 0xff);
       LV1_idT      = new TH1F("LV1_idT", "LV1_idT", 255, 0x0, 0xff);
-      BX_idT       = new TH1F("BX_idT", "BX_idT", 4095, 0x0, 0xfff);
       BX_diff      = new TH1F("BX_diff", "BX_diff", 8191, -4095, 4095);
-      //EvtLength    = new TH1F("EvtLength", "EvtLength", 0xffffff, 0x0, 0xffffff);
-      //CRC_cdf      = new TH1F("CRC_cdf", "CRC_cdf", 0xffff, 0x0, 0xffff);
     }
-    
+
     //!Fills the histograms for AMC13 data
     /*!
      This fills histograms for the following data: control_bit5, control_bitA, Evt_ty, LV1_id, BX_id, Source_id, CalTyp, nAMC, Blk_Not, LV1_idT, BX_idT, EvtLength, and CRC_cdf
@@ -49,19 +43,16 @@ class AMC13_histogram: public Hardware_histogram
       nAMC->Fill(amc13->nAMC());
       Control_bit5->Fill(amc13->cb_5());
       Evt_ty->Fill(amc13->Evt_ty());
-      //LV1_id->Fill(amc13->LV1_id());
-      //BX_id->Fill(amc13->BX_id());
       OrN->Fill(amc13->OrN());
       Source_id->Fill(amc13->Source_id());
       CalTyp->Fill(amc13->CalTyp());
       Blk_NoT->Fill(amc13->Blk_NoT());
       LV1_idT->Fill(amc13->LV1_idT());
-      //BX_idT->Fill(amc13->BX_idT());
       Control_bitA->Fill(amc13->cbA());
       BX_diff->Fill(amc13->BX_idT()-amc13->BX_id());
     }
 
-     
+
     //!Adds an AMC_histogram object to the m_amcsH vector
     void addAMCH(AMC_histogram* amcH, int i){m_amcsH[i]=amcH;}
 
@@ -73,17 +64,11 @@ class AMC13_histogram: public Hardware_histogram
     TH1F* Control_bitA;                   ///<Histogram for control bit A
     TH1F* Control_bit5;                   ///<Histogram for control bit 5
     TH1F* Evt_ty;                         ///<Histogram for Evt_ty
-    //TH1F* LV1_id;                         ///<Histogram for LV1_id
-    TH1F* BX_id;                          ///<Histogram for BX_id
     TH1F* Source_id;                      ///<Histogram for Source_id
     TH1F* CalTyp;                         ///<Histogram for CalTyp
     TH1F* nAMC;                           ///<Histogram for nAMC
     TH1D* OrN;                            ///<Histogram for OrN
-    //TH1F* CRC_amc13;                      ///<Histogram for CRC_amc13
     TH1F* Blk_NoT;                        ///<Histogram for Blk_Not
     TH1F* LV1_idT;                        ///<Histogram for LV1_idT
-    TH1F* BX_idT;                         ///<Histogram for BX_idT
     TH1F* BX_diff;
-    //TH1F* EvtLength;                      ///<Histogram for EvtLength
-    //TH1F* CRC_cdf;                        ///<Histogram for CRC_cdf
 };

--- a/dqm-root/src/common/AMC_histogram.cxx
+++ b/dqm-root/src/common/AMC_histogram.cxx
@@ -24,7 +24,7 @@ class AMC_histogram: public Hardware_histogram
       }
       m_dir->cd();
       AMCnum     = new TH1F("AMCnum", "AMC number", 12,  0, 12);
-      //L1A        = new TH1F("L1A", "L1A ID", 0xffffff,  0x0, 0xffffff);      
+      //L1A        = new TH1F("L1A", "L1A ID", 0xffffff,  0x0, 0xffffff);
       BX         = new TH1F("BX", "BX ID", 4095,  0x0, 0xfff);
       //Dlength    = new TH1F("Dlength", "Data Length", 0xfffff,  0x0, 0xfffff);
       FV         = new TH1F("FV", "Format Version", 15,  0x0, 0xf);
@@ -40,10 +40,6 @@ class AMC_histogram: public Hardware_histogram
       Tstate     = new TH1F("Tstate", "TTS state", 15,  0, 15);
       ChamT      = new TH1F("ChamT", "Chamber Timeout", 24, 0, 24);
       OOSG       = new TH1F("OOSG", "OOS GLIB", 1, 0, 1);
-      CRC        = new TH1D("CRC", "CRC", 0xffff, 0, 0xffff);// histogram overflow! Can't handle 32-bit number...
-      latencyBX2D = new TH2D("latencyBX2D", "Latency vs BX", 256,  -0.5, 255.5, 4096,  -0.5,4095.5);
-      //L1AT       = new TH1F("L1AT", "L1AT", 0xffffff,  0x0, 0xffffff);
-      //DlengthT   = new TH1F("DlengthT", "DlengthT", 0xffffff,  0x0, 0xffffff);
     }
 
      //!Fills the histograms for AMC data
@@ -65,10 +61,6 @@ class AMC_histogram: public Hardware_histogram
       GDcount->Fill(amc->GDcount());
       Tstate->Fill(amc->Tstate());
       OOSG->Fill(amc->OOSG());
-      CRC->Fill(amc->CRC());
-      latencyBX2D->Fill(amc->Param3(),amc->BX());
-      //L1AT->Fill(amc->L1AT());
-      //DlengthT->Fill(amc->DlengthT());
       uint8_t binFired = 0;
       for (int bin = 0; bin < 24; bin++){
         binFired = ((amc->GEMDAV() >> bin) & 0x1);
@@ -102,9 +94,5 @@ class AMC_histogram: public Hardware_histogram
     TH1F* Tstate;                         ///<Histogram for TTS state
     TH1F* ChamT;                          ///<Histogram for Chamber Timeout
     TH1F* OOSG;                           ///<Histogram for OOS GLIB
-    TH1D* CRC;                            ///<Histogram for CRC
-    TH1F* L1AT;                           ///<Histogram for L1AT
-    TH1F* DlengthT;                       ///<Histogram for Data Length (trailer)
-    TH2D* latencyBX2D;                    ///<Distribution of number of events per BX and latency bin
 };
 

--- a/dqm-root/src/common/GEB_histogram.cxx
+++ b/dqm-root/src/common/GEB_histogram.cxx
@@ -58,7 +58,7 @@ public:
     for (int i = 1; i<11; i++) Warnings->GetXaxis()->SetBinLabel(i, warning_flags[i-1]);
     //OHCRC    = new TH1F("OHCRC", "OH CRC", 0xffff,  0x0 , 0xffff);
     Vwt      = new TH1F("Vwt", "VFAT word count", 4095,  0x0 , 0xfff);
-    BeamProfile      = new TH2I("BeamProfile", "2D Occupancy", 8, 0, 8, 384, 0, 384);
+    //BeamProfile      = new TH2I("BeamProfile", "2D Occupancy", 8, 0, 8, 384, 0, 384);
     ClusterMult      = new TH1I("ClusterMult", "Cluster multiplicity", 384,  0, 384 );
     ClusterSize      = new TH1I("ClusterSize", "Cluster size", 384,  0, 384 );
     for(int ie=0; ie < NETA; ie++){
@@ -66,11 +66,6 @@ public:
       ClusterSizeEta  [ie] = new TH1I(("ClusterSize"+std::to_string(static_cast <long long> (ie))).c_str(), "Cluster size", 384,  0, 384 );
     }
     SlotN   = new TH1I("VFATSlots", "VFAT Slots", 24,  0, 24);
-    //Totalb1010 = new TH1F("Totalb1010", "Control Bit 1010", 15,  0x0 , 0xf);
-    //Totalb1100 = new TH1F("Totalb1100", "Control Bit 1100", 15,  0x0 , 0xf);
-    //Totalb1110 = new TH1F("Totalb1110", "Control Bit 1110", 15,  0x0 , 0xf);
-    //TotalFlag  = new TH1F("TotalFlag", "Control Flags", 15,  0x0 , 0xf);
-    TotalCRC   = new TH1F("TotalCRC", "CRC Mismatches", 0xffff,-32768,32768);
   }
 
 
@@ -195,17 +190,12 @@ private:
   TH1I* Warnings;                          ///<Histogram for Warnings (InFIFO underflow, Stuck Data)
   //TH1F* OHCRC;                             ///<Histogram for OH CRC
   TH1F* Vwt;                               ///<Histogram for VFAT word count (trailer)
-  TH2I* BeamProfile;                       ///<Histogram for 2D BeamProfile
+  //TH2I* BeamProfile;                       ///<Histogram for 2D BeamProfile
   TH1I* ClusterMult;                       ///<Histogram for GEB cluster multiplicity
   TH1I* ClusterSize;                       ///<Histogram for GEB cluster size
   TH1I* ClusterMultEta[NETA];              ///<Histogram for GEB eta cluster multiplicity
   TH1I* ClusterSizeEta[NETA];              ///<Histogram for GEB eta cluster size
   TH1I* SlotN;                             ///<Histogram for VFAT slots
-  TH1F* Totalb1010;			     // Add all vfat control bit histograms
-  TH1F* Totalb1100;
-  TH1F* Totalb1110;
-  TH1F* TotalFlag;
-  TH1F* TotalCRC;
 
   std::map<int, GEMStripCollection> allstrips;
   VFATdata * m_vfat;

--- a/dqm-root/src/common/dqmMain.cxx
+++ b/dqm-root/src/common/dqmMain.cxx
@@ -12,91 +12,13 @@
 
 using namespace std;
 
-TList *getConfig(string filename)
-{
-  MYSQL *Database;
-  Database = connectDB();
-  string RunName;
-  if(filename.find("chunk") == string::npos) {
-    RunName = filename.substr(filename.find("run"),filename.find(".raw.root")-filename.find("run"));
-  }
-  else {
-    RunName = filename.substr(filename.find("run"),filename.find("_chunk")-filename.find("run"));
-  }
-  std::cout << "Run Name " << RunName <<std::endl;
-  TList * config = new TList();
-  TList * amc = new TList();
-  TMap * geb = new TMap();
-  TObjString * slot = new TObjString();
-  TObjString * chipID = new TObjString();
-  config->SetName("config");
-  string AMC13Query = "select id from ldqm_db_run where Name like '";
-  AMC13Query += RunName;
-  AMC13Query += "'";
-
-  string RunIDstr = stringFromChar(simpleDBQuery(Database, AMC13Query));
-  
-  string AMCQuery = "select amc_id from ldqm_db_run_amcs where run_id like '"+RunIDstr+"'";
-  vector<string> AMCs = manyDBQuery(Database,AMCQuery);
-  if (DEBUG) cout << "Number of AMCs: " << AMCs.size() << endl;
-  for ( int iamc = 0; iamc < AMCs.size(); iamc++ )
-  {
-    string currentAMCid = stringFromChar(AMCs.at(iamc).c_str());
-    string AMCBidQuery = "select BoardID from ldqm_db_amc where id like '"+currentAMCid+"'";
-    char* AMCBidchar = simpleDBQuery(Database,AMCBidQuery);
-    string AMCBidstr(AMCBidchar);
-    string aslot_ch = AMCBidstr.substr(AMCBidstr.find("-")+1,AMCBidstr.size()-2);
-    long long int a_slot = atoi(aslot_ch.c_str());
-    amc->SetName(to_string(a_slot).c_str());
-    string GEBQuery = "select geb_id from ldqm_db_amc_gebs where amc_id like '"+currentAMCid+"'";
-    vector<string> GEBs = manyDBQuery(Database,GEBQuery);
-    if (DEBUG) cout << "Number of GEBs: " << GEBs.size() << endl;
-    for ( int igeb = 0; igeb < GEBs.size(); igeb++ )
-    {
-      string currentGEBid = stringFromChar(GEBs.at(igeb).c_str());
-      string GEBBidQuery = "select ChamberID from ldqm_db_geb where id like '"+currentGEBid+"'";
-      char* GEBBidchar = simpleDBQuery(Database,GEBBidQuery);
-      string GEBBidstr(GEBBidchar);
-      string gslot_ch = GEBBidstr.substr(GEBBidstr.find("-")+1,GEBBidstr.size());
-      long long int g_slot = atoi(gslot_ch.c_str());
-      geb->SetName(to_string(g_slot).c_str());
-      string VFATQuery = "select vfat_id from ldqm_db_geb_vfats where geb_id like '"+currentGEBid+"'";
-      vector<string> VFATs = manyDBQuery(Database,VFATQuery);
-      if (DEBUG) cout << "Number of VFATs: " << VFATs.size() << endl;
-      for ( int ivfat = 0; ivfat < VFATs.size(); ivfat++ )
-      {
-        string currentVFATid = stringFromChar(VFATs.at(ivfat).c_str());
-        string VFATSlotQuery = "select Slot from ldqm_db_vfat where id like '"+currentVFATid+"'";
-        char* VFATSlotchar = simpleDBQuery(Database,VFATSlotQuery);
-        long long int v_slot = atoi(VFATSlotchar);
-        string VFATdirname = "VFAT-";
-        VFATdirname += to_string(v_slot);
-        string VFATChipQuery = "select ChipID from ldqm_db_vfat where id like '"+currentVFATid+"'";
-        char* VFATChipchar = simpleDBQuery(Database,VFATChipQuery);
-        int v_chipid = strtol(VFATChipchar, NULL, 16);
-
-        slot->SetString(to_string(v_slot).c_str());
-        chipID->SetString(to_string(v_chipid).c_str());
-        geb->Add((TObject*)slot->Clone(),(TObject*)chipID->Clone());
-      } /* END VFAT LOOP */
-      amc->Add(geb->Clone());
-      geb->Clear();
-    } /* END GEB LOOP */
-    config->Add(amc->Clone());
-    amc->Clear();
-    //if (DEBUG) cout << "Add AMC histograms to AMC13 for amc in " << a_slot << endl;
-  } /* END AMC LOOP */
-
-  return config;
-}
-
 int main(int argc, char** argv)
 {
   //gErrorIgnoreLevel = kError;
   gProofDebugMask = TProofDebug::kAll;
   gProofDebugLevel = 5;
   std::cout << "--==DQM Main==--" << endl;
-  if (argc<2) 
+  if (argc<2)
     {
       cout << "Please provide input filenames" << endl;
       cout << "Usage: <path>/rundqm inputFile.root" << endl;
@@ -124,16 +46,13 @@ int main(int argc, char** argv)
   if (tmp != ".raw.root") throw std::runtime_error("Wrong input filename (should end with '.raw.root'): "+ifilename);
   ofilename = ifilename.substr(0,ifilename.size()-9);
   ofilename += ".analyzed.root";
- 
+
   gSystem->Load("libEvent.so");
   TChain *ch = new TChain ("GEMtree","chain");
   ch->Add(ifilename.c_str());
 
-  TList * m_config = new TList();
-  //m_config = getConfig(ifilename);
 
-  TProof::Open("workers=2");
-  //gProof->AddInput(m_config);
+  TProof::Open("workers=4");
   gProof->AddInput(new TNamed("PROOF_OUTPUTFILE", ofilename.c_str()));
   gProof->GetInputList()->Print();
   ch->SetProof();;

--- a/dqm-root/src/common/gemTreeReader.cxx
+++ b/dqm-root/src/common/gemTreeReader.cxx
@@ -28,37 +28,7 @@
 class gemTreeReader: public TSelector {
 public :
   TTree          *fChain;   //!pointer to the analyzed TTree or TChain
-   TTreeReader     fReader;  //!the tree reader
-
-   // Readers to access the data (delete the ones you do not need).
-   TTreeReaderValue<unsigned int> fUniqueID = {fReader, "fUniqueID"};
-   TTreeReaderValue<unsigned int> fBits = {fReader, "fBits"};
-   TTreeReaderValue<Int_t> fEvtHdr_fEvtNum = {fReader, "fEvtHdr.fEvtNum"};
-   TTreeReaderValue<Int_t> fEvtHdr_fRun = {fReader, "fEvtHdr.fRun"};
-   TTreeReaderValue<Int_t> fEvtHdr_fDate = {fReader, "fEvtHdr.fDate"};
-   TTreeReaderArray<UChar_t> famc13s_m_cb5 = {fReader, "famc13s.m_cb5"};
-   TTreeReaderArray<UChar_t> famc13s_m_Evt_ty = {fReader, "famc13s.m_Evt_ty"};
-   TTreeReaderArray<unsigned int> famc13s_m_LV1_id = {fReader, "famc13s.m_LV1_id"};
-   TTreeReaderArray<unsigned short> famc13s_m_BX_id = {fReader, "famc13s.m_BX_id"};
-   TTreeReaderArray<unsigned short> famc13s_m_Source_id = {fReader, "famc13s.m_Source_id"};
-   TTreeReaderArray<UChar_t> famc13s_m_CalTyp = {fReader, "famc13s.m_CalTyp"};
-   TTreeReaderArray<UChar_t> famc13s_m_nAMC = {fReader, "famc13s.m_nAMC"};
-   TTreeReaderArray<unsigned int> famc13s_m_OrN = {fReader, "famc13s.m_OrN"};
-   TTreeReaderArray<UChar_t> famc13s_m_cb0 = {fReader, "famc13s.m_cb0"};
-   TTreeReaderArray<vector<unsigned int>> famc13s_m_AMC_size = {fReader, "famc13s.m_AMC_size"};
-   TTreeReaderArray<vector<unsigned char>> famc13s_m_Blk_No = {fReader, "famc13s.m_Blk_No"};
-   TTreeReaderArray<vector<unsigned char>> famc13s_m_AMC_No = {fReader, "famc13s.m_AMC_No"};
-   TTreeReaderArray<vector<unsigned short>> famc13s_m_BoardID = {fReader, "famc13s.m_BoardID"};
-   TTreeReaderArray<vector<AMCdata>> famc13s_m_amcs = {fReader, "famc13s.m_amcs"};
-   TTreeReaderArray<unsigned int> famc13s_m_CRC_amc13 = {fReader, "famc13s.m_CRC_amc13"};
-   TTreeReaderArray<UChar_t> famc13s_m_Blk_NoT = {fReader, "famc13s.m_Blk_NoT"};
-   TTreeReaderArray<UChar_t> famc13s_m_LV1_idT = {fReader, "famc13s.m_LV1_idT"};
-   TTreeReaderArray<unsigned short> famc13s_m_BX_idT = {fReader, "famc13s.m_BX_idT"};
-   TTreeReaderArray<UChar_t> famc13s_m_cbA = {fReader, "famc13s.m_cbA"};
-   TTreeReaderArray<unsigned int> famc13s_m_EvtLength = {fReader, "famc13s.m_EvtLength"};
-   TTreeReaderArray<unsigned short> famc13s_m_CRC_cdf = {fReader, "famc13s.m_CRC_cdf"};
-   TTreeReaderValue<Bool_t> fisEventGood = {fReader, "fisEventGood"};
-
+  TTreeReader     fReader;  //!the tree reader
 
   // Declaration of leaf types
   Event           *GEMEvents;
@@ -80,8 +50,6 @@ public :
   virtual TList  *GetOutputList() const { return fOutput; }
   virtual void    SlaveTerminate();
   virtual void    Terminate();
-
-  //int slotFromMap(int a, int g, int cid);
 
   vector<AMC13Event> v_amc13;    ///<Vector of AMC13Event
   vector<AMCdata> v_amc;         ///<Vector of AMCdata
@@ -152,14 +120,9 @@ void gemTreeReader::SlaveBegin(TTree * /*tree*/)
   }
   fFile->cd();
 
-  //VFATMap = {{{0}}};
   TObjString * diramc13 = new TObjString("AMC13-1");
   m_amc13H = new AMC13_histogram("preved", gDirectory->mkdir(diramc13->String()), "1");
   m_amc13H->bookHistograms();
-  if (DEBUG) std::cout << "Slave Begin: try to get config "<< std::endl;
-  TList *config_s = (TList*)fInput->FindObject("config");
-  if (DEBUG) std::cout << "Slave Begin: retrieved config name " << config_s->GetName() << std::endl;
-  if (DEBUG) std::cout << "Slave Begin: try to get config iterator"<< std::endl;
 
   int iAMCSlots[] = {2,4,6}; //Change slots here
   std::vector<int> vec_amcSlots(iAMCSlots, iAMCSlots + sizeof(iAMCSlots) / sizeof(int) );
@@ -187,60 +150,6 @@ void gemTreeReader::SlaveBegin(TTree * /*tree*/)
     gDirectory->cd("..");       //moves back to previous directory
     m_amc13H->addAMCH(m_amcH,(*iterAMC));
   }
-
-  //TIter nextamc(config_s);
-  //TObject *amc;
-  //while ((amc = nextamc()))
-  //{
-  //  std::cout << "Slave Begin: found object " << amc->GetName() << std::endl;
-  //  TString a_slot_s = (TString) amc->GetName();
-  //  int a_slot = a_slot_s.Atoi(); // retrieve a_slot from the config somehow
-  //  a_slot_s.Insert(0,"AMC-");
-  //  m_amcH = new AMC_histogram("preved", gDirectory->mkdir(a_slot_s.Data()), amc->GetName());
-  //  m_amcH->bookHistograms();
-  //  TIter nextgeb((TList*)amc);
-  //  TObject *geb;
-  //  while ((geb = nextgeb()))
-  //  {
-  //    std::cout << "Slave Begin: found object " << geb->GetName() << std::endl;
-  //    TString g_slot_s = (TString)geb->GetName();
-  //    int g_slot = g_slot_s.Atoi(); // retrieve g_slot from the config somehow
-  //    // FIXME!!! Tmp plug to correct offset introduced in the DB
-  //    g_slot = g_slot -1;
-  //    g_slot_s.Form("%d",g_slot);
-  //    g_slot_s.Insert(0,"GTX-");
-  //    // end of FIXME
-  //    m_gebH = new GEB_histogram("preved", gDirectory->mkdir(g_slot_s.Data()), geb->GetName());
-  //    m_gebH->bookHistograms();
-  //    TMapIter nextvfat((TMap*)geb);
-  //    TPair *vfat;
-  //    while ((vfat = (TPair*)nextvfat()))
-  //    {
-  //      //TObject *chipID_s = ((TPair*)geb->FindObject(vfat))->Value();
-  //      TString v_slot_s = (TString)vfat->GetName();
-  //      //TString s_chipID_s = (TString)chipID_s->GetName();
-  //      //if (DEBUG) cout << "s_chipID_s " << s_chipID_s << endl;
-  //      //s_chipID_s = TString::BaseConvert(s_chipID_s, 16,10);
-  //      int v_slot = v_slot_s.Atoi(); // retrieve v_slot from the config somehow
-  //      //int i_chipID = s_chipID_s.Atoi();
-  //      //i_chipID = i_chipID & 0x0FFF;
-  //      //VFATMap[a_slot][g_slot][v_slot] = i_chipID;
-  //      //if (DEBUG) cout << "Insert chip ID " << i_chipID << " in place a,g,v: " << a_slot << ", " << g_slot << ", " << v_slot << endl;
-  //      v_slot_s.Insert(0,"VFAT-");
-  //      m_vfatH = new VFAT_histogram("preved", gDirectory->mkdir(v_slot_s.Data()), to_string(v_slot).c_str());
-  //      m_vfatH->bookHistograms();
-  //      m_gebH->addVFATH(m_vfatH,v_slot);
-  //      std::cout << "Slave Begin: add vfat " << v_slot << std::endl;
-  //      gDirectory->cd("..");   //moves back to previous directory
-  //    } /* END VFAT LOOP */
-  //    gDirectory->cd("..");     //moves back to previous directory
-  //    m_amcH->addGEBH(m_gebH,g_slot);
-  //    std::cout << "Slave Begin: add geb " << g_slot << std::endl;
-  //  } /* END GEB LOOP */
-  //  gDirectory->cd("..");       //moves back to previous directory
-  //  m_amc13H->addAMCH(m_amcH, a_slot);
-  //  std::cout << "Slave Begin: add amc " << a_slot << std::endl;
-  //} /* END AMC LOOP */
 
   gDirectory = savedir;
   if (DEBUG) std::cout << "SLAVE END"<< std::endl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Stripping a number of VFAT and other histograms to reduce the memory consumption. 
Fixes #32 
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested at QC8 PC with QC8 data

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
