### PR TITLE
Restoring 2D Latency Scan Histogram to VFAT_Histograms

### DIFF
--- a/dqm-root/src/common/VFAT_histogram.cxx
+++ b/dqm-root/src/common/VFAT_histogram.cxx
@@ -27,8 +27,8 @@ public:
     Header     = new TH1F("Header", "Header", 32,  0x0 , 0xff);
     SlotN    = new TH1F("SlotN", "Slot Number", 24,  0, 24);
     FiredChannels = new TH1F("FiredChannels", "FiredChannels", 128, -0.5, 127.5);
-    //FiredStrips   = new TH1F("FiredStrips",   "FiredStrips",   128, -0.5, 127.5);
     latencyScan   = new TH1F("latencyScan",   "Latency Scan", 256,  -0.5, 255.5);
+    latencyScan2D = new TH2F("latencyScan2D", "Latency Scan: Chan Vs Latency", 1024, -0.5, 1023.5, NCHANNELS, -0.5, NCHANNELS-0.5);
     const char *warning_labels[3] = {"Flag raised", "No channels fired", "Excessive channels fired"};
     const char *error_labels[1] = {"CRC mismatch"};
     Warnings = new TH1I("Warnings", "Warnings", 3,  0, 3);
@@ -95,12 +95,14 @@ public:
 	    chan0xf = ((vfat->lsData() >> i) & 0x1);
 	    if(chan0xf) {
 	      channelFired = true;
+          latencyScan2D->Fill(latency,i);
           n_h_fired++;
 	    }
       } else {
 	    chan0xf = ((vfat->msData() >> (i-64)) & 0x1);
 	    if(chan0xf) {
 	      channelFired = true;
+          latencyScan2D->Fill(latency,i);
           n_h_fired++;
 	    }
       }
@@ -122,6 +124,7 @@ private:
   TH1F* FiredChannels;    ///<Histogram for Fired Channels (uses lsData and fmData)
   TH1F* SlotN;
   TH1F* latencyScan;
+  TH2F* latencyScan2D;
   TH1I* Warnings;
   TH1I* Errors;
   int m_sn;

--- a/dqm-root/src/common/VFAT_histogram.cxx
+++ b/dqm-root/src/common/VFAT_histogram.cxx
@@ -27,7 +27,7 @@ public:
     Header     = new TH1F("Header", "Header", 32,  0x0 , 0xff);
     SlotN    = new TH1F("SlotN", "Slot Number", 24,  0, 24);
     FiredChannels = new TH1F("FiredChannels", "FiredChannels", 128, -0.5, 127.5);
-    latencyScan   = new TH1F("latencyScan",   "Latency Scan", 256,  -0.5, 255.5);
+    latencyScan   = new TH1F("latencyScan",   "Latency Scan", 1024,  -0.5, 1023.5);
     latencyScan2D = new TH2F("latencyScan2D", "Latency Scan: Chan Vs Latency", 1024, -0.5, 1023.5, NCHANNELS, -0.5, NCHANNELS-0.5);
     const char *warning_labels[3] = {"Flag raised", "No channels fired", "Excessive channels fired"};
     const char *error_labels[1] = {"CRC mismatch"};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing comment made [here](https://github.com/cms-gem-daq-project/gem-light-dqm/issues/32#issuecomment-476315515)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

It's sort of a bug fix...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-analyzed previous raw.root file.

### Screenshots (if appropriate):

<img width="802" alt="Screen Shot 2019-03-26 at 11 30 30 AM" src="https://user-images.githubusercontent.com/6432141/54990508-33ea9100-4fbb-11e9-97bd-1f0088d287c9.png">

Note this run had one of the PMTs turned off so all triggers did not really go through the detectors so plot is expected to be ~empty.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
